### PR TITLE
chore: add semantic-pr config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,1 @@
+titleAndCommits: true


### PR DESCRIPTION
Override default semantic-prs config to require semantic commits and PR titles